### PR TITLE
Add basic Datadog monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,11 @@ CORS_ORIGIN=http://localhost:5173
 # DEVELOPMENT EXAMPLES (NO USAR EN PRODUCCIÓN)
 # JWT_SECRET=dev-jwt-secret-123456789012345678901234
 # JWT_REFRESH_SECRET=dev-refresh-secret-123456789012345678901234
+
+# DATADOG CONFIGURATION
+# Habilitar trazas y métricas de Datadog
+DATADOG_ENABLED=false
+# Nombre del servicio reportado a Datadog
+DATADOG_SERVICE=jwt-example-backend
+# Entorno para Datadog (development, staging, production, etc.)
+DATADOG_ENV=local

--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ npm run dev
 - **Frontend:** http://localhost:5173
 - **API Backend:** http://localhost:3000/api
 
+### 5. **Monitoreo con Datadog**
+
+Para enviar trazas y métricas a Datadog:
+
+```env
+DATADOG_ENABLED=true
+DATADOG_SERVICE=jwt-example-backend
+DATADOG_ENV=local
+```
+
+Asegúrate de tener un agente de Datadog en ejecución y luego inicia el backend con `npm run dev`.
+
 ## 📚 Guía de Aprendizaje para Estudiantes
 
 ### 🎯 **Nivel 1: Conceptos Básicos (30-45 min)**

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
-    "cors": "^2.8.5"
+    "cors": "^2.8.5",
+    "dd-trace": "^4.8.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,24 @@
 // 📦 IMPORTACIONES Y DEPENDENCIAS PRINCIPALES
 // ===================================================================================================
 
+// ============================================================================
+// 📈 INTEGRACIÓN CON DATADOG (MONITOREO)
+// ============================================================================
+
+// Importar el tracer de Datadog para habilitar monitoreo APM
+// La inicialización debe ocurrir antes de cargar Express para instrumentarlo
+import tracer from 'dd-trace';
+
+if (process.env.DATADOG_ENABLED === 'true') {
+  tracer.init({
+    service: process.env.DATADOG_SERVICE || 'jwt-example-backend',
+    env: process.env.DATADOG_ENV || 'development',
+    logInjection: true
+  });
+  tracer.use('express');
+  console.log('📈 Datadog tracing habilitado');
+}
+
 // Framework Express.js para crear el servidor HTTP y manejar rutas REST
 // Express es el framework web más popular para Node.js, proporciona routing, middleware y manejo de HTTP
 import express from 'express';


### PR DESCRIPTION
## Summary
- add Datadog env variables
- integrate `dd-trace` in the backend
- document Datadog setup in README
- include `dd-trace` dependency

## Testing
- `npm run --prefix backend build` *(fails: Cannot find module 'dd-trace')*

------
https://chatgpt.com/codex/tasks/task_e_6866d1566fb88321961847a24b763337